### PR TITLE
Code quality: fix 9 bugs and bad practices across the codebase

### DIFF
--- a/athletes/serializers.py
+++ b/athletes/serializers.py
@@ -31,5 +31,7 @@ class AthleteProfileSerializer(serializers.ModelSerializer):
             "role",
             "belt",
             "stripes",
+            "weight",
+            "mat_hours",
         ]
-        read_only_fields = ["user", "role", "academy"]
+        read_only_fields = ["user", "role", "academy", "mat_hours"]

--- a/athletes/views.py
+++ b/athletes/views.py
@@ -1,8 +1,11 @@
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 
+from academies.models import Academy
 from core.mixins import AcademyFilterMixin, SwaggerSafeMixin
+from core.models import AcademyMembership
 from core.permissions import IsAcademyMember
 
 from .models import AthleteProfile
@@ -25,20 +28,25 @@ class AthleteProfileViewSet(SwaggerSafeMixin, AcademyFilterMixin, viewsets.Model
         if getattr(self, "swagger_fake_view", False):
             return super().get_queryset()
 
-        # H-2 fix: Enforce tenant isolation with membership validation
-        # CONSISTENCY FIX: Use 'academy' parameter like other views (was 'academy_id')
         if self.request.user.is_superuser:
             return self.filter_by_academy(
                 AthleteProfile.objects.select_related("user", "academy")
             )
 
-        # For regular users, validate membership and return scoped queryset
-        validated_queryset = self.get_academy_scoped_queryset(AthleteProfile.objects.all())
-        if validated_queryset is not AthleteProfile.objects.none():
-            return self.filter_by_academy(
-                AthleteProfile.objects.select_related("user", "academy")
-            )
-        return validated_queryset
+        academy_id = self.get_academy_id()
+        if not academy_id:
+            return AthleteProfile.objects.none()
+
+        # Explicit membership check — avoids the broken `is not queryset.none()`
+        # identity comparison (two .none() calls are never the same object).
+        if not AcademyMembership.objects.filter(
+            user=self.request.user, academy_id=academy_id, is_active=True
+        ).exists():
+            return AthleteProfile.objects.none()
+
+        return AthleteProfile.objects.filter(
+            academy_id=academy_id
+        ).select_related("user", "academy")
 
     def get_permissions(self):
         """
@@ -61,8 +69,6 @@ class AthleteProfileViewSet(SwaggerSafeMixin, AcademyFilterMixin, viewsets.Model
     def perform_create(self, serializer):
         academy_id = self.get_academy_id()
         if academy_id:
-            from academies.models import Academy
-            from django.shortcuts import get_object_or_404
             academy = get_object_or_404(Academy, pk=academy_id)
             serializer.save(academy=academy)
         else:
@@ -79,7 +85,6 @@ class AthleteProfileViewSet(SwaggerSafeMixin, AcademyFilterMixin, viewsets.Model
             is_own_profile = obj.user == user
 
             # Check if user is professor/owner of the academy
-            from core.models import AcademyMembership
             is_professor_or_owner = AcademyMembership.objects.filter(
                 user=user,
                 academy=obj.academy,

--- a/community/services.py
+++ b/community/services.py
@@ -132,23 +132,28 @@ class StatsAggregationService:
     def get_summary(athlete: AthleteProfile) -> dict:
         """Return a stats dictionary for the athlete profile page.
 
-        P4 fix: collapse total_check_ins and achievements_count into a single
-        aggregate() call to avoid 2 extra sequential COUNT queries.
+        Uses a single annotated query to fetch total_check_ins and
+        achievements_count in one round-trip instead of two separate COUNTs.
         """
         from django.db.models import Count
 
-        agg = athlete.check_ins.aggregate(total=Count("id"))
-        total_check_ins = agg["total"]
-
-        achievements_count = athlete.achievements.count()
+        result = (
+            AthleteProfile.objects.filter(pk=athlete.pk)
+            .annotate(
+                total_check_ins=Count("check_ins", distinct=True),
+                achievements_count=Count("achievements", distinct=True),
+            )
+            .values("total_check_ins", "achievements_count", "mat_hours")
+            .get()
+        )
 
         return {
-            "total_check_ins": total_check_ins,
-            "mat_hours": athlete.mat_hours,
+            "total_check_ins": result["total_check_ins"],
+            "mat_hours": result["mat_hours"],
             "current_streak_days": StatsAggregationService.compute_current_streak(
                 athlete
             ),
-            "achievements_count": achievements_count,
+            "achievements_count": result["achievements_count"],
         }
 
 

--- a/matches/models.py
+++ b/matches/models.py
@@ -32,6 +32,13 @@ class Match(models.Model):
             ),
         ]
 
+    def __str__(self):
+        return (
+            f"Match #{self.pk}: "
+            f"{self.athlete_a} vs {self.athlete_b} "
+            f"({'finished' if self.is_finished else 'in progress'})"
+        )
+
 
 class MatchEvent(models.Model):
 
@@ -47,3 +54,6 @@ class MatchEvent(models.Model):
     points_awarded = models.IntegerField(default=0)
     action_description = models.CharField(max_length=100)
     event_type = models.CharField(max_length=15, choices=TypeChoices.choices)
+
+    def __str__(self):
+        return f"{self.event_type} by {self.athlete} at {self.timestamp}s (match #{self.match_id})"

--- a/matches/views.py
+++ b/matches/views.py
@@ -109,15 +109,24 @@ class MatchViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # H-4 fix: winner must be one of the two participants
-        valid_participant_ids = {str(match.athlete_a_id), str(match.athlete_b_id)}
-        if str(winner_id) not in valid_participant_ids:
+        # winner_id must be one of the two participants; compare as integers to
+        # avoid silent mismatches from string/int type coercion.
+        try:
+            winner_id = int(winner_id)
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "winner_id must be an integer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if winner_id not in (match.athlete_a_id, match.athlete_b_id):
             return Response(
                 {"error": "winner_id must be one of the match participants."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        match.is_finished = True
-        match.winner_id = winner_id
-        match.save()
+        # Use update() with update_fields to avoid overwriting concurrent score
+        # changes made by add_event between get_object() and this save().
+        Match.objects.filter(pk=match.pk).update(is_finished=True, winner_id=winner_id)
+        match.refresh_from_db()
         return Response(MatchSerializer(match).data, status=status.HTTP_200_OK)

--- a/tatami/selectors.py
+++ b/tatami/selectors.py
@@ -1,20 +1,28 @@
+from typing import Optional
+
 from django.db.models import QuerySet
 
 from .models import Matchup, TimerPreset, TimerSession
 
 
-def get_presets_for_academy(academy_id: int) -> QuerySet:
+def get_presets_for_academy(academy_id: Optional[int]) -> QuerySet:
+    if not academy_id:
+        return TimerPreset.objects.none()
     return TimerPreset.objects.filter(academy_id=academy_id)
 
 
-def get_active_sessions(academy_id: int) -> QuerySet:
+def get_active_sessions(academy_id: Optional[int]) -> QuerySet:
+    if not academy_id:
+        return TimerSession.objects.none()
     return TimerSession.objects.filter(
         preset__academy_id=academy_id,
         status__in=[TimerSession.Status.RUNNING, TimerSession.Status.PAUSED],
     ).select_related("preset")
 
 
-def get_matchups_for_academy(academy_id: int, match_format: str = None) -> QuerySet:
+def get_matchups_for_academy(academy_id: Optional[int], match_format: str = None) -> QuerySet:
+    if not academy_id:
+        return Matchup.objects.none()
     qs = Matchup.objects.filter(academy_id=academy_id).select_related(
         "athlete_a__user", "athlete_b__user", "weight_class", "winner__user"
     )

--- a/tatami/serializers.py
+++ b/tatami/serializers.py
@@ -93,9 +93,12 @@ class MatchupSerializer(serializers.ModelSerializer):
 
 
 class PairAthletesSerializer(serializers.Serializer):
-    """Input for the pair_athletes action."""
+    """Input for the pair_athletes action.
+
+    academy is intentionally absent — it is derived from the ?academy= query
+    param so the caller cannot supply a foreign academy ID in the request body.
+    """
 
     athlete_ids = serializers.ListField(child=serializers.IntegerField(), min_length=2)
     match_format = serializers.ChoiceField(choices=Matchup.MatchFormat.choices)
     weight_class_id = serializers.IntegerField(required=False, allow_null=True)
-    academy_id = serializers.IntegerField()

--- a/tatami/services.py
+++ b/tatami/services.py
@@ -184,7 +184,9 @@ class TimerService:
             raise ValueError("Can only pause a running timer.")
         session.paused_at = timezone.now()
         session.status = session.Status.PAUSED
-        delta = (session.paused_at - session.started_at).seconds
+        # .total_seconds() returns the full duration; .seconds only gives the
+        # seconds component (0–59), giving wrong results for durations > 1 min.
+        delta = int((session.paused_at - session.started_at).total_seconds())
         session.elapsed_seconds += delta
         session.save(update_fields=["paused_at", "status", "elapsed_seconds"])
 

--- a/tatami/views.py
+++ b/tatami/views.py
@@ -40,9 +40,8 @@ class TimerPresetViewSet(SwaggerSafeMixin, AcademyFilterMixin, viewsets.ModelVie
         if getattr(self, "swagger_fake_view", False):
             return super().get_queryset()
 
-        # M-4 fix: Academy-scoped timer presets
         academy_id = self.get_academy_id()
-        return selectors.get_presets_for_academy(academy_id or 0)
+        return selectors.get_presets_for_academy(academy_id)
 
     def get_permissions(self):
         if self.request.method in ("GET", "HEAD", "OPTIONS"):
@@ -72,9 +71,8 @@ class TimerSessionViewSet(SwaggerSafeMixin, AcademyFilterMixin, viewsets.ModelVi
         if getattr(self, "swagger_fake_view", False):
             return super().get_queryset()
 
-        # M-4 fix: Academy-scoped timer sessions
         academy_id = self.get_academy_id()
-        return selectors.get_active_sessions(academy_id or 0)
+        return selectors.get_active_sessions(academy_id)
 
     @action(detail=True, methods=["post"])
     def pause(self, request, pk=None):
@@ -113,9 +111,8 @@ class MatchupViewSet(SwaggerSafeMixin, AcademyFilterMixin, viewsets.ModelViewSet
         if getattr(self, "swagger_fake_view", False):
             return super().get_queryset()
 
-        # M-3/M-4 fix: Academy-scoped matchups
         academy_id = self.get_academy_id()
-        return selectors.get_matchups_for_academy(academy_id or 0)
+        return selectors.get_matchups_for_academy(academy_id)
 
     @extend_schema(
         request=PairAthletesSerializer, responses=MatchupSerializer(many=True)
@@ -126,9 +123,11 @@ class MatchupViewSet(SwaggerSafeMixin, AcademyFilterMixin, viewsets.ModelViewSet
         serializer.is_valid(raise_exception=True)
         d = serializer.validated_data
 
+        # Derive academy from the authenticated query param — do NOT accept it
+        # from the request body to prevent IDOR (supplying a foreign academy PK).
         from academies.models import Academy
 
-        academy = get_object_or_404(Academy, pk=d["academy_id"])
+        academy = get_object_or_404(Academy, pk=self.get_academy_id() or 0)
 
         # M-3 fix: filter athletes by BOTH pk list AND academy, so a professor
         # cannot inject athletes from a foreign academy into a matchup.

--- a/techniques/models.py
+++ b/techniques/models.py
@@ -5,9 +5,19 @@ from core.mixins import TimestampMixin
 from core.models import Belt
 
 
-# TODO:
-# slug podría ser obligatorio para URLs amigables.
-class TechniqueCategory(models.Model):
+class AutoSlugMixin(models.Model):
+    """Abstract mixin: auto-populates `slug` from `name` on first save."""
+
+    class Meta:
+        abstract = True
+
+    def save(self, *args, **kwargs):
+        if not self.slug:
+            self.slug = slugify(self.name)
+        super().save(*args, **kwargs)
+
+
+class TechniqueCategory(AutoSlugMixin, models.Model):
     name = models.CharField(max_length=100, unique=True)
     description = models.TextField(blank=True)
     slug = models.SlugField(max_length=120, unique=True, blank=True, null=True)
@@ -15,16 +25,11 @@ class TechniqueCategory(models.Model):
     class Meta:
         ordering = ["name"]
 
-    def save(self, *args, **kwargs):
-        if not self.slug:
-            self.slug = slugify(self.name)
-        super().save(*args, **kwargs)
-
     def __str__(self):
         return self.name
 
 
-class Technique(TimestampMixin, models.Model):
+class Technique(AutoSlugMixin, TimestampMixin, models.Model):
 
     class DifficultyLevel(models.IntegerChoices):
         ONE = 1, "1 Star"
@@ -56,11 +61,6 @@ class Technique(TimestampMixin, models.Model):
 
     class Meta:
         ordering = ["name"]
-
-    def save(self, *args, **kwargs):
-        if not self.slug:
-            self.slug = slugify(self.name)
-        super().save(*args, **kwargs)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
BUG — tatami/services.py: .seconds only returns the 0-59 seconds component of a timedelta; replace with .total_seconds() so elapsed time accumulates correctly for timer sessions longer than 1 minute.

BUG — athletes/views.py: get_queryset() used `is not queryset.none()` which is always True (different object references). Replace with an explicit AcademyMembership check, matching the pattern used in TrainingClassViewSet. Also move deferred imports (Academy, get_object_or_404, AcademyMembership) to module-level to follow standard Python style.

BUG — matches/views.py finish_match: winner_id was compared as a string against string-cast FKs, hiding type mismatches. Now parsed to int and compared directly. match.save() replaced with Match.objects.filter().update() to avoid overwriting concurrent score changes made by add_event.

BUG — community/services.py get_summary(): comment claimed a single aggregate() call was used but two separate COUNT queries were issued. Fixed to a single annotated queryset (.annotate(total_check_ins, achievements_count)) that fetches both counts in one round-trip.

DRY — techniques/models.py: TechniqueCategory and Technique both duplicated the same slug auto-generation save() logic. Extracted into AutoSlugMixin.

SECURITY/DRY — tatami/serializers.py + tatami/views.py: academy_id was accepted in the PairAthletesSerializer request body, allowing IDOR (caller supplies a foreign academy PK). Removed from serializer; pair_athletes now derives academy exclusively from the authenticated ?academy= query param.

API — athletes/serializers.py: weight and mat_hours were missing from the serialized fields even though they are core matchmaking and progress metrics. Added both; mat_hours is read_only (managed atomically by CheckInService).

QUALITY — matches/models.py: Match and MatchEvent had no __str__ methods, making them unreadable in the admin, shell, and error logs.

QUALITY — tatami/selectors.py + tatami/views.py: selectors were called with `academy_id or 0`, which would silently filter for academy_id=0 (no results but no error). Selectors now guard against falsy academy_id and return .none() explicitly; views pass academy_id directly.

https://claude.ai/code/session_01FnH3haBkrF4JJ9EmrD773B