### PR TITLE
Hook up StatsService.recompute_for_athlete in finish_match

### DIFF
--- a/matches/services.py
+++ b/matches/services.py
@@ -80,6 +80,19 @@ class MatchService:
 
         Match.objects.filter(pk=match.pk).update(is_finished=True, winner_id=winner_id)
         match.refresh_from_db()
+
+        # Recompute cached stats for both participants now that the match is finished.
+        # Local import avoids a circular dependency (stats.services imports matches.models).
+        from athletes.models import AthleteProfile
+        from stats.services import StatsService
+
+        for user_id in (match.athlete_a_id, match.athlete_b_id):
+            try:
+                athlete = AthleteProfile.objects.get(user_id=user_id)
+                StatsService.recompute_for_athlete(athlete)
+            except AthleteProfile.DoesNotExist:
+                pass
+
         return match
 
     @staticmethod


### PR DESCRIPTION
After a match is finished, recompute cached AthleteMatchStats for both
participants so the stats/leaderboard views always reflect the full
match history. Uses a local import to avoid the circular dependency
between matches.services and stats.services (which imports matches.models).

https://claude.ai/code/session_01GQb34qctVAqHkFzZBiLtJW